### PR TITLE
Fix hashed password handling

### DIFF
--- a/src/com/company/User.java
+++ b/src/com/company/User.java
@@ -80,12 +80,18 @@ public class User {
     }
 
     public void setPassword(String password) {
+        if (password == null) {
+            System.out.println("Password cannot be null");
+            return;
+        }
 
-        if (StrongPasswordRecognizer.isPasswordStrong(password))
+        boolean isHashed = password.matches("^[0-9a-fA-F]{96}$");
+
+        if (isHashed || StrongPasswordRecognizer.isPasswordStrong(password)) {
             this.password = password;
-            
-        else
-            System.out.println("Password is not strong enough");    
+        } else {
+            System.out.println("Password is not strong enough");
+        }
     }
 
     public void setName(String name) {

--- a/test/com/company/UserTest.java
+++ b/test/com/company/UserTest.java
@@ -372,7 +372,7 @@ public class UserTest {
 	}
 
 	@Test
-	public void testUserPropertyCombinations() {
+        public void testUserPropertyCombinations() {
 		// Test setting all properties with edge case values
 		String edgeCaseName = "John O'Connor-Smith 123";
 		String edgeCaseEmail = "john.123@sub.example.com";
@@ -389,8 +389,16 @@ public class UserTest {
 		assertEquals(edgeCaseName, user.getName(), "Edge case name should be preserved");
 		assertEquals(edgeCaseEmail, user.getEmail(), "Edge case email should be preserved");
 		assertEquals(edgeCasePassword, user.getPassword(), "Edge case password should be preserved");
-		assertEquals(edgeCaseType, user.getType(), "Edge case type should be preserved");
-		assertEquals(edgeCaseID, user.getUserID(), "Edge case ID should be preserved");
-	}
+                assertEquals(edgeCaseType, user.getType(), "Edge case type should be preserved");
+                assertEquals(edgeCaseID, user.getUserID(), "Edge case ID should be preserved");
+        }
+
+        @Test
+        public void testSetHashedPassword() {
+                AuthenticationService auth = new AuthenticationService(new UserDatabaseHelper());
+                String hashed = auth.hashPassword("Test123!");
+                user.setPassword(hashed);
+                assertEquals(hashed, user.getPassword());
+        }
 
 }


### PR DESCRIPTION
## Summary
- allow setting hashed passwords in `User` without failing strength check
- add test covering hashed password updates

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_683f4ccecd848323a990c078de025dad